### PR TITLE
Replace the hotspots confidence ladder with boolean arithmetic (#3737)

### DIFF
--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -1469,29 +1469,16 @@ def _calc_hotspots_numpy(z_array):
         for x in prange(cols):
             zscore = z_array[y, x]
 
-            # find p value
-            p_value = 1.0
-            if abs(zscore) >= 2.33:
-                p_value = 0.0099
-            elif abs(zscore) >= 1.65:
-                p_value = 0.0495
-            elif abs(zscore) >= 1.29:
-                p_value = 0.0985
-
-            # confidence
-            confidence = 0
-            if abs(zscore) > 2.58 and p_value < 0.01:
-                confidence = 99
-            elif abs(zscore) > 1.96 and p_value < 0.05:
-                confidence = 95
-            elif abs(zscore) > 1.65 and p_value < 0.1:
-                confidence = 90
-
-            hot_cold = 0
-            if zscore > 0:
-                hot_cold = 1
-            elif zscore < 0:
-                hot_cold = -1
+            # Confidence is 99 for |z| > 2.58, 95 for 1.96 < |z| <= 2.58,
+            # 90 for 1.65 < |z| <= 1.96, else 0. The GPU twin
+            # (_gpu_hotspots) spells this out as a p-value / confidence
+            # ladder; the p-value tests there are implied by the |z|
+            # tests, so the ladder collapses to these three thresholds.
+            # NaN compares False everywhere and classifies to 0.
+            az = abs(zscore)
+            confidence = (90 * (az > 1.65) + 5 * (az > 1.96)
+                          + 4 * (az > 2.58))
+            hot_cold = (zscore > 0) - (zscore < 0)
 
             out[y, x] = hot_cold * confidence
     return out

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -1470,14 +1470,12 @@ def _calc_hotspots_numpy(z_array):
             zscore = z_array[y, x]
 
             # Confidence is 99 for |z| > 2.58, 95 for 1.96 < |z| <= 2.58,
-            # 90 for 1.65 < |z| <= 1.96, else 0. The GPU twin
-            # (_gpu_hotspots) spells this out as a p-value / confidence
-            # ladder; the p-value tests there are implied by the |z|
-            # tests, so the ladder collapses to these three thresholds.
-            # NaN compares False everywhere and classifies to 0.
+            # 90 for 1.65 < |z| <= 1.96, else 0. This is the p-value /
+            # confidence ladder collapsed to the three thresholds that
+            # reach the output. NaN compares False everywhere and
+            # classifies to 0.
             az = abs(zscore)
-            confidence = (90 * (az > 1.65) + 5 * (az > 1.96)
-                          + 4 * (az > 2.58))
+            confidence = 90 * (az > 1.65) + 5 * (az > 1.96) + 4 * (az > 2.58)
             hot_cold = (zscore > 0) - (zscore < 0)
 
             out[y, x] = hot_cold * confidence

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -1569,6 +1569,31 @@ def test_hotspots_classifier_thresholds_3737():
     np.testing.assert_array_equal(out, expected)
 
 
+def test_hotspots_classifier_float32_3737():
+    # The production callers feed the classifier float32 z-scores
+    # (_hotspots_numpy casts before classifying). The thresholds are
+    # float64 literals, so a float32 input is promoted before comparison:
+    # np.float32(1.65) sits just below 1.65 and np.float32(1.96) just
+    # above it. Pin that the float32 result equals the classification of
+    # the same values widened to float64, so a dtype-specific comparison
+    # cannot creep in.
+    from xrspatial.focal import _calc_hotspots_numpy
+
+    thresholds = np.array([1.29, 1.65, 1.96, 2.33, 2.58])
+    z = np.stack([np.nextafter(thresholds, -np.inf), thresholds,
+                  np.nextafter(thresholds, np.inf)])
+    z = np.concatenate([z, -z]).astype(np.float32)
+    z = np.concatenate([np.nextafter(z, np.float32(-np.inf)), z,
+                        np.nextafter(z, np.float32(np.inf))])
+
+    out32 = _calc_hotspots_numpy(z)
+    out64 = _calc_hotspots_numpy(z.astype(np.float64))
+    assert out32.dtype == np.int8
+    np.testing.assert_array_equal(out32, out64)
+    # The float32 grid must still hit every band on both sides.
+    assert set(np.unique(out32).tolist()) == {-99, -95, -90, 0, 90, 95, 99}
+
+
 def test_hotspots_classifier_nonfinite_3737():
     # NaN compares False against every threshold and classifies to 0;
     # +/-inf land in the top band with the matching sign; signed zeros

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -1541,6 +1541,46 @@ def test_hotspots_dask_cupy():
         dask_cupy_hotspots.data[pad:-pad, pad:-pad].compute().get())
 
 
+def test_hotspots_classifier_thresholds_3737():
+    # Regression for #3737: the z-score classifier was rewritten from a
+    # nine-branch threshold ladder into boolean arithmetic. Pin the
+    # classification at every threshold and its float64 neighbours, at
+    # both signs, so the open/closed side of each interval cannot drift.
+    from xrspatial.focal import _calc_hotspots_numpy
+
+    thresholds = np.array([1.29, 1.65, 1.96, 2.33, 2.58])
+    below = np.nextafter(thresholds, -np.inf)
+    above = np.nextafter(thresholds, np.inf)
+    z = np.stack([below, thresholds, above])
+    z = np.concatenate([z, -z])
+
+    # Confidence is 99 for |z| > 2.58, 95 for 1.96 < |z| <= 2.58,
+    # 90 for 1.65 < |z| <= 1.96, else 0. 1.29 and 2.33 are p-value
+    # thresholds in the original ladder and never change the output.
+    expected = np.array([
+        [0, 0, 90, 95, 95],     # just below each threshold
+        [0, 0, 90, 95, 95],     # exactly on each threshold
+        [0, 90, 95, 95, 99],    # just above each threshold
+    ], dtype=np.int8)
+    expected = np.concatenate([expected, -expected])
+
+    out = _calc_hotspots_numpy(z)
+    assert out.dtype == np.int8
+    np.testing.assert_array_equal(out, expected)
+
+
+def test_hotspots_classifier_nonfinite_3737():
+    # NaN compares False against every threshold and classifies to 0;
+    # +/-inf land in the top band with the matching sign; signed zeros
+    # are neither hot nor cold.
+    from xrspatial.focal import _calc_hotspots_numpy
+
+    z = np.array([[np.nan, np.inf, -np.inf, 0.0, -0.0]])
+    out = _calc_hotspots_numpy(z)
+    assert out.dtype == np.int8
+    np.testing.assert_array_equal(out, [[0, 99, -99, 0, 0]])
+
+
 @dask_array_available
 @cuda_and_cupy_available
 def test_hotspots_dask_cupy_matches_numpy():


### PR DESCRIPTION
Closes #3737

- `_calc_hotspots_numpy` classified each Gi* z-score through a nine-branch `if/elif` ladder that recomputed `abs(zscore)` up to six times per cell. The p-value half of that ladder never changed the output: each `p_value < threshold` test is implied by the `|z|` test beside it (`|z| > 2.58` forces `p = 0.0099`, `|z| > 1.96` and `|z| > 1.65` both force `p <= 0.0495`). The whole thing reduces to 99 for `|z| > 2.58`, 95 for `1.96 < |z| <= 2.58`, 90 for `1.65 < |z| <= 1.96`, else 0.
- The classifier now computes `confidence = 90*(az > 1.65) + 5*(az > 1.96) + 4*(az > 2.58)` and `hot_cold = (z > 0) - (z < 0)`. A comment above the code states the collapsed thresholds so nobody has to re-derive them. Output dtype (int8) and signature are unchanged.
- The CUDA device function `_gpu_hotspots` still uses the ladder. It is not on the timed CPU path and branch cost on the GPU is a separate question, so it is left alone here.

## Timings

`_calc_hotspots_numpy` alone, 2000x4000 float64 z-scores, median of 5 after warmup, 20-core host:

| input | before | after |
|---|---|---|
| random normal (sd 1.5) | 18.1 ms | 11.6 ms |
| smooth ramp | 18.3 ms | 12.6 ms |
| random normal, 10% NaN | 18.9 ms | 12.1 ms |

Identical int8 results in every case.

## Verification

The original function was extracted from `origin/main` into a scratch module and compared with `np.array_equal` against the new one on:

- 2000x4000 `rng.normal(0, 1.5)` in float64 and float32
- a dense `np.linspace(-4, 4, 2_000_001)` sweep that crosses every threshold at both signs
- the exact values `+/-1.29, 1.65, 1.96, 2.33, 2.58` and their float64 neighbours via `np.nextafter`
- NaN, +inf, -inf, +0.0, -0.0

All equal. The threshold-neighbour and non-finite cases are now pytest tests (`test_hotspots_classifier_thresholds_3737`, `test_hotspots_classifier_nonfinite_3737`) with hand-derived expected values.

Backends: numpy and dask+numpy share this kernel and both benefit. cupy and dask+cupy use the untouched CUDA kernel.

## Test plan

- [x] `pytest xrspatial/tests/test_focal.py -x -q` (353 passed, GPU tests included on a CUDA box)
- [x] A/B equality against the `origin/main` implementation on the inputs listed above
- [x] Before/after timing on 2000x4000 float64

No benchmark change: `FocalHotspots` in `benchmarks/benchmarks/focal.py` already covers `hotspots()`.
