### PR TITLE
Drop the per-cell NaN early-out in the planar CPU slope kernel

### DIFF
--- a/benchmarks/benchmarks/slope.py
+++ b/benchmarks/benchmarks/slope.py
@@ -29,10 +29,13 @@ class SlopeNaN(Benchmarking):
         ny = nx // 2
         agg = get_xr_dataarray((ny, nx), type, include_nan=True)
         rng = np.random.default_rng(71942)
-        speckle = rng.random((ny, nx)) < 0.3
+        speckle = rng.random((ny, nx), dtype=np.float32) < 0.3
         self.xr = agg.where(~speckle)
 
     def time_slope_nan(self, nx, type):
+        # Force the compute so the dask case times the kernel rather than
+        # graph construction. Slope.time_slope does not, so the dask numbers
+        # of the two classes are not directly comparable.
         result = self.func(self.xr)
         if hasattr(result.data, "compute"):
             result.data.compute()

--- a/benchmarks/benchmarks/slope.py
+++ b/benchmarks/benchmarks/slope.py
@@ -1,6 +1,8 @@
+import numpy as np
+
 from xrspatial import slope
 
-from .common import Benchmarking
+from .common import Benchmarking, get_xr_dataarray
 
 
 class Slope(Benchmarking):
@@ -9,3 +11,28 @@ class Slope(Benchmarking):
 
     def time_slope(self, nx, type):
         return self.time(nx, type)
+
+
+class SlopeNaN(Benchmarking):
+    # Speckled nodata: the planar CPU kernel's cost depends on whether the
+    # NaN pattern is predictable, so time it separately from Slope.
+    # get_xr_dataarray(include_nan=True) only sets the [0, 0] corner to NaN,
+    # which is on the border the kernel never visits, so add 30% random NaN
+    # over the interior on top of it.
+    params = ([100, 300, 1000, 3000, 10000], ["numpy", "dask"])
+    param_names = ("nx", "type")
+
+    def __init__(self):
+        super().__init__(func=slope)
+
+    def setup(self, nx, type):
+        ny = nx // 2
+        agg = get_xr_dataarray((ny, nx), type, include_nan=True)
+        rng = np.random.default_rng(71942)
+        speckle = rng.random((ny, nx)) < 0.3
+        self.xr = agg.where(~speckle)
+
+    def time_slope_nan(self, nx, type):
+        result = self.func(self.xr)
+        if hasattr(result.data, "compute"):
+            result.data.compute()

--- a/xrspatial/slope.py
+++ b/xrspatial/slope.py
@@ -54,8 +54,11 @@ def _cpu(data, cellsize_x, cellsize_y):
     rows, cols = data.shape
     for y in range(1, rows - 1):
         for x in range(1, cols - 1):
-            if np.isnan(data[y, x]):
-                continue
+            # No early-out on a NaN centre: the branch is unpredictable on
+            # speckled nodata and costs more than the arithmetic it skips.
+            # Neighbour NaN already propagates through the stencil; the centre
+            # is folded back in with a select so out[y, x] is NaN whenever
+            # data[y, x] is.
             a = data[y + 1, x - 1]
             b = data[y + 1, x]
             c = data[y + 1, x + 1]
@@ -67,7 +70,9 @@ def _cpu(data, cellsize_x, cellsize_y):
             dz_dx = ((c + 2 * f + i) - (a + 2 * d + g)) / (8 * cellsize_x)
             dz_dy = ((g + 2 * h + i) - (a + 2 * b + c)) / (8 * cellsize_y)
             p = (dz_dx * dz_dx + dz_dy * dz_dy) ** .5
-            out[y, x] = np.arctan(p) * 57.29578
+            r = np.arctan(p) * 57.29578
+            ctr = data[y, x]
+            out[y, x] = r if ctr == ctr else np.nan
     return out
 
 

--- a/xrspatial/slope.py
+++ b/xrspatial/slope.py
@@ -43,7 +43,7 @@ def _geodesic_cuda_dims(shape):
 
 
 # =====================================================================
-# Planar backend functions (unchanged)
+# Planar backend functions
 # =====================================================================
 
 @ngjit

--- a/xrspatial/tests/test_slope.py
+++ b/xrspatial/tests/test_slope.py
@@ -625,3 +625,47 @@ def test_units_overridden_to_degrees_geodesic():
     result = slope(raster, method='geodesic')
     assert result.attrs['units'] == 'degrees'
     assert raster.attrs['units'] == 'm'
+
+
+# The planar CPU kernel has no per-cell NaN early-out (#3739): neighbour NaN
+# flows through the Horn stencil and the centre is masked with a select. Pin
+# the resulting footprint on speckled nodata so a future edit can't widen or
+# shrink it: NaN at every centre-NaN cell and its 8-neighbours, finite
+# everywhere else in the interior.
+def _speckled_nan_data():
+    rng = np.random.default_rng(3739)
+    data = rng.normal(0, 2, size=(40, 60))
+    data[rng.random(data.shape) < 0.1] = np.nan
+    return data
+
+
+def _expected_nan_footprint(data):
+    nan_mask = np.isnan(data)
+    footprint = np.zeros_like(nan_mask)
+    for dy in (-1, 0, 1):
+        for dx in (-1, 0, 1):
+            footprint[1:-1, 1:-1] |= nan_mask[1 + dy:data.shape[0] - 1 + dy,
+                                              1 + dx:data.shape[1] - 1 + dx]
+    footprint[0, :] = footprint[-1, :] = footprint[:, 0] = footprint[:, -1] = True
+    return footprint
+
+
+def test_speckled_nan_footprint_numpy():
+    data = _speckled_nan_data()
+    agg = create_test_raster(data, backend='numpy', attrs={'res': (1, 1)})
+    result = slope(agg)
+    general_output_checks(agg, result, verify_attrs=False)
+    np.testing.assert_array_equal(np.isnan(result.data), _expected_nan_footprint(data))
+    assert np.all(np.isfinite(result.data[~np.isnan(result.data)]))
+
+
+@dask_array_available
+def test_speckled_nan_footprint_dask_numpy():
+    data = _speckled_nan_data()
+    numpy_agg = create_test_raster(data, backend='numpy', attrs={'res': (1, 1)})
+    dask_agg = create_test_raster(data, backend='dask+numpy',
+                                  attrs={'res': (1, 1)}, chunks=(16, 24))
+    assert_numpy_equals_dask_numpy(numpy_agg, dask_agg, slope, nan_edges=False,
+                                   verify_attrs=False)
+    np.testing.assert_array_equal(np.isnan(slope(dask_agg).data.compute()),
+                                  _expected_nan_footprint(data))

--- a/xrspatial/tests/test_slope.py
+++ b/xrspatial/tests/test_slope.py
@@ -631,7 +631,9 @@ def test_units_overridden_to_degrees_geodesic():
 # flows through the Horn stencil and the centre is masked with a select. Pin
 # the resulting footprint on speckled nodata so a future edit can't widen or
 # shrink it: NaN at every centre-NaN cell and its 8-neighbours, finite
-# everywhere else in the interior.
+# everywhere else in the interior. The old kernel produced the same footprint,
+# so these pass on either version; they pin behaviour rather than reproduce a
+# regression.
 def _speckled_nan_data():
     rng = np.random.default_rng(3739)
     data = rng.normal(0, 2, size=(40, 60))


### PR DESCRIPTION
Closes #3739

- Drop the `if np.isnan(data[y, x]): continue` early-out at the top of the planar CPU slope kernel `_cpu`. Neighbour NaN already propagates through the Horn stencil, and `out` is pre-filled with NaN, so the only case the branch covered was a NaN centre with valid neighbours. That is now handled by a select after the arithmetic (`out[y, x] = r if ctr == ctr else np.nan`). No fastmath, no dtype change, neighbour loads in the same order.
- Add a `SlopeNaN` asv benchmark (numpy and dask, same `nx` grid as `Slope`) so the nodata path gets timed from now on.
- Add tests that pin the NaN footprint on a speckled raster: NaN at every centre-NaN cell and its 8-neighbours, finite everywhere else in the interior, on numpy and dask+numpy.

Backends: numpy and dask+numpy share `_cpu`, so both get the change. The cupy and dask+cupy kernels and the geodesic kernels are untouched.

## Why

On DEMs with scattered nodata the early-out is a data-dependent branch the CPU cannot predict, and the mispredicts cost more than the few float32 ops and one `arctan` the skip avoids.

## Timings

2000x4000 float32 DEM (Gaussian bump plus `default_rng(71942).normal(0, 2)` noise), `_cpu` called directly, `time.perf_counter`, median of 9 after warmup. Three separate runs on a box that had other test suites running at the same time, so the absolute numbers wobble; the ratios hold up.

| NaN pattern | before | after | ratio |
|---|---|---|---|
| none | 102 to 107 ms | 92 to 101 ms | 0.90x to 0.98x |
| 30% random NaN | 90 to 94 ms | 53 to 67 ms | 0.58x to 0.72x |
| left half NaN | 79 to 81 ms | 70 to 77 ms | 0.86x to 0.97x |

Identical results in every regime: `np.array_equal(old, new, equal_nan=True)` holds against the `_cpu` from `origin/main` for the three rasters above plus 3x3, 1x50, 50x1, 2x50, a 3x3 with a NaN centre, and an int16 200x300 input.

The NaN-free case is unchanged within noise. A contiguous NaN block is only a small win because the predictor learns it. The gain is specific to speckled nodata such as masked water or cloud holes, where the kernel is roughly 1.5x to 2x faster. The spike that motivated this measured 0.47x on a quiet machine; I could not get the box that quiet with the sibling runs going.

## On the benchmark's NaN pattern

`get_xr_dataarray(include_nan=True)` in `benchmarks/benchmarks/common.py` sets exactly one cell, `z[0, 0]`, to NaN. That is a border cell the kernel never visits, so on its own it times the NaN-free path again. `SlopeNaN.setup` calls it with `include_nan=True` and then masks 30% of cells at random (fixed seed) with `DataArray.where`, which keeps the dask array lazy for the dask case. Verified the resulting NaN fraction is 0.301 on both backends. `common.py` is not modified. The dask case forces `.compute()` so asv times the kernel rather than graph construction, following the twi and convolution benchmarks.

## Test plan

- [x] `pytest xrspatial/tests/test_slope.py -x -q`: 137 passed
- [x] Direct A/B against `origin/main`'s `_cpu` on the nine inputs listed above, all bitwise identical
- [x] `SlopeNaN.setup` and `time_slope_nan` run for numpy and dask at nx=1000
- [x] flake8 on the three touched files reports only the pre-existing aligned rows in the QGIS fixture (same 30 hits before and after)
