### PR TITLE
Fix the test-fixture CRS string that pyproj 3.8.0 rejects

### DIFF
--- a/xrspatial/tests/general_checks.py
+++ b/xrspatial/tests/general_checks.py
@@ -32,7 +32,7 @@ def create_test_raster(
         backend='numpy',
         name='myraster',
         dims=['y', 'x'],
-        attrs={'res': (0.5, 0.5), 'crs': 'EPSG: 5070'},
+        attrs={'res': (0.5, 0.5), 'crs': 'EPSG:5070'},
         chunks=(3, 3)
 ):
     raster = xr.DataArray(data, name=name, dims=dims, attrs=attrs)

--- a/xrspatial/tests/test_aspect.py
+++ b/xrspatial/tests/test_aspect.py
@@ -271,7 +271,7 @@ def _rectangular_cell_raster(backend='numpy', xres=10.0, yres=1.0):
     data = (X + Y).astype(np.float64)
     return create_test_raster(
         data, backend=backend,
-        attrs={'res': (xres, yres), 'crs': 'EPSG: 5070'})
+        attrs={'res': (xres, yres), 'crs': 'EPSG:5070'})
 
 
 @pytest.mark.parametrize("backend", ['numpy', 'dask+numpy'])

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -1052,7 +1052,7 @@ class TestCRSPropagation:
         """return_type='geopandas' copies agg.attrs['crs'] onto the gdf."""
         pytest.importorskip("geopandas")
         data = _make_peak()
-        # create_test_raster sets attrs={'res': ..., 'crs': 'EPSG: 5070'}.
+        # create_test_raster sets attrs={'res': ..., 'crs': 'EPSG:5070'}.
         agg = create_test_raster(data, backend='numpy')
         gdf = contours(agg, levels=[1.5], return_type="geopandas")
         # GeoPandas normalizes the CRS; check it resolves to EPSG:5070.

--- a/xrspatial/tests/test_multispectral.py
+++ b/xrspatial/tests/test_multispectral.py
@@ -891,7 +891,7 @@ def _tc_band(backend):
     data = np.random.default_rng(3429).random((6, 6)).astype(np.float32)
     return create_test_raster(
         data, backend=backend, dims=['lat', 'lon'],
-        attrs={'res': (0.5, 0.5), 'crs': 'EPSG: 5070'},
+        attrs={'res': (0.5, 0.5), 'crs': 'EPSG:5070'},
     )
 
 

--- a/xrspatial/tests/test_preview.py
+++ b/xrspatial/tests/test_preview.py
@@ -521,7 +521,7 @@ def test_res_passthrough_unchanged():
 def test_no_res_attr_stays_absent():
     """preview should not invent a res when the input never had one."""
     data = np.random.default_rng(1).random((200, 400)).astype(np.float32)
-    agg = create_test_raster(data, attrs={'crs': 'EPSG: 5070'})
+    agg = create_test_raster(data, attrs={'crs': 'EPSG:5070'})
     assert 'res' not in agg.attrs
     result = preview(agg, width=40)
     assert 'res' not in result.attrs


### PR DESCRIPTION
Every `pytest` run on `main` has been red since the 2026-09-06 nightly. Same 12 failures on every job, all in `xrspatial/tests/test_contour.py`:

```
pyproj.exceptions.CRSError: Invalid projection: EPSG: 5070: (Internal Proj Error: proj_create: unrecognized format / unknown name)
```

Note the space after the colon. `create_test_raster` in `general_checks.py` has set `attrs['crs']` to `'EPSG: 5070'` since January, and three other test modules copied the string. PROJ up to 9.7 parsed it anyway, so nobody noticed.

pyproj 3.8.0 hit PyPI on 2026-09-05 at 20:03 UTC and bundles PROJ 9.8.1, which rejects the spaced form. The nightly that morning passed, the next one failed. Only contour breaks because `contours(return_type='geopandas')` is the one path in these tests that passes the raw attribute to `GeoDataFrame`, and geopandas parses it with pyproj. Checked in a scratch venv:

```
pyproj 3.8.0 / PROJ 9.8.1:  'EPSG:5070' -> 5070   'EPSG: 5070' -> CRSError
pyproj 3.7.2 / PROJ 9.7.1:  'EPSG:5070' -> 5070   'EPSG: 5070' -> 5070
```

The fix is to write `'EPSG:5070'` in the five test files. No library change and no pyproj pin. The spaced spelling was only ever a fixture value, and pinning would keep a bad string alive in the tests.

Verified locally: `test_contour.py`, `test_aspect.py`, `test_multispectral.py` and `test_preview.py` pass under pyproj 3.8.0 and under 3.7.2. The rest of the fast lane under pyproj 3.8.0: 10605 passed, 2838 skipped, 1 xfailed, 0 failed.

https://claude.ai/code/session_014AFA91bMkXvxmcTqEwGbaF
