### PR TITLE
Accept target_values=None in surface_distance trio (#3712)

### DIFF
--- a/xrspatial/surface_distance.py
+++ b/xrspatial/surface_distance.py
@@ -1383,6 +1383,9 @@ def _compute(raster, elevation, x, y, target_values, max_distance,
     signed_cellsize_x = cellsize_x * _coord_step_sign(raster, x)
     signed_cellsize_y = cellsize_y * _coord_step_sign(raster, y)
 
+    if target_values is None:
+        target_values = []
+
     target_values = np.asarray(target_values, dtype=np.float64)
     if target_values.ndim != 1:
         raise ValueError(
@@ -1528,7 +1531,7 @@ def surface_distance(
     elevation: xr.DataArray,
     x: str = "x",
     y: str = "y",
-    target_values: list = [],
+    target_values: list = None,
     max_distance: float = np.inf,
     connectivity: int = 8,
     method: str = 'planar',
@@ -1584,7 +1587,7 @@ def surface_allocation(
     elevation: xr.DataArray,
     x: str = "x",
     y: str = "y",
-    target_values: list = [],
+    target_values: list = None,
     max_distance: float = np.inf,
     connectivity: int = 8,
     method: str = 'planar',
@@ -1621,7 +1624,7 @@ def surface_direction(
     elevation: xr.DataArray,
     x: str = "x",
     y: str = "y",
-    target_values: list = [],
+    target_values: list = None,
     max_distance: float = np.inf,
     connectivity: int = 8,
     method: str = 'planar',

--- a/xrspatial/tests/test_surface_distance.py
+++ b/xrspatial/tests/test_surface_distance.py
@@ -613,6 +613,16 @@ def test_invalid_target_values_shape(bad):
         surface_distance(source, elev, target_values=bad)
 
 
+@pytest.mark.parametrize("func", [surface_distance, surface_allocation, surface_direction])
+def test_target_values_none_matches_empty(func):
+    """target_values=None must behave like the [] default (issue #3712)."""
+    source = _make_raster(np.array([[0.0, 1.0, 0.0, 2.0, 0.0]], dtype=np.float64))
+    elev = _make_raster(np.zeros((1, 5), dtype=np.float64))
+    expected = _compute(func(source, elev))
+    got = _compute(func(source, elev, target_values=None))
+    np.testing.assert_array_equal(np.asarray(got), np.asarray(expected))
+
+
 # ---------------------------------------------------------------------------
 # Tests — dask-specific
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #3712

## Proposed Changes

  - `surface_distance`, `surface_allocation`, `surface_direction` now accept `target_values=None` (the value wrapper code passes when its own optional arg is unset), matching `proximity` / `allocation` / `direction` / `cost_distance`.
  - Changed the three signatures from `target_values: list = []` to `target_values: list = None` and added the sibling `if target_values is None: target_values = []` guard in the shared `_compute` dispatcher.
  - Added a regression test (`test_target_values_none_matches_empty`) parametrized over all three functions.

## Why / evidence

The proximity trio and `cost_distance` all declare `target_values: list = None` and normalize to `[]` in the body. The three `surface_*` functions declared `target_values: list = []` with no `None` guard, so `target_values=None` fell through to `np.asarray(None, dtype=np.float64)` (a 0-d array) and blew up before the numba kernel. On numpy 2.3 it surfaces as the existing `ValueError: target_values must be a 1-D sequence`; the issue reports a ~40-line numba TypingError on older numpy. Either way it is broken. `[]` as a default is also the mutable-default anti-pattern the siblings already avoid.

Confirmed with the reproduction from #3712 on this checkout: pre-fix, `surface_distance/allocation/direction(target_values=None)` raise while the other four return normally; post-fix all seven succeed.

## Change

`[]` and `None` both mean "treat every non-zero finite pixel as a source", so callers passing an explicit list are unaffected and callers passing `None` go from a traceback to working code. No parameter renamed, no accepted input changes meaning, so no deprecation shim is needed.

Note: `balanced_allocation` carries the same `target_values: list = []` default (flagged in #3712 as out of scope) and is left untouched here.

## Verified

```
$ python -m pytest xrspatial/tests/test_surface_distance.py -q
81 passed, 19 skipped

$ python -m pytest xrspatial/tests/test_surface_distance.py -q -k target_values
6 passed, 94 deselected

$ python repro_3712.py   # reproduction script from the issue
proximity(target_values=None) -> OK
allocation(target_values=None) -> OK
direction(target_values=None) -> OK
cost_distance(target_values=None) -> OK
surface_distance(target_values=None) -> OK
surface_allocation(target_values=None) -> OK
surface_direction(target_values=None) -> OK
```

flake8 / isort: no new violations introduced by this change (the pre-existing `surface_distance.py` isort drift is tracked separately in #3710).
